### PR TITLE
NEW Add lazy_init optional kwarg

### DIFF
--- a/time_execution/decorator.py
+++ b/time_execution/decorator.py
@@ -79,7 +79,7 @@ class time_execution(Decorator):
 
 
 if PY_35_GT:
-    from fqn_decorators.async import AsyncDecorator  # isort:skip
+    from fqn_decorators.async import AsyncDecorator  # isort:skip  # noqa: W606
 
     class time_execution_async(AsyncDecorator, time_execution):
         pass

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ deps =
 [testenv:py35]
 deps =
     {[testenv]deps}
-    pytest-asyncio==0.6.0
 
 [testenv:lint]
 basepython = python3.5


### PR DESCRIPTION
The lazy_init kwarg can be used to avoid a bug that leads to no metrics
being sent by the ThreadedBackend when used in a Celery project with
--max-memory-per-child param.
See: https://github.com/kpn-digital/py-timeexecution/issues/37