### PR TITLE
FIX: Do not overwrite timestamp if already provided

### DIFF
--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -61,7 +61,6 @@ class BaseTestTimeExecutionElasticSearch(TestBaseBackend):
 
 class TestTimeExecution(BaseTestTimeExecutionElasticSearch):
     def test_time_execution(self):
-
         count = 4
 
         for i in range(count):
@@ -110,7 +109,6 @@ class TestTimeExecution(BaseTestTimeExecutionElasticSearch):
 
     @mock.patch("time_execution.backends.elasticsearch.logger")
     def test_error_warning(self, mocked_logger):
-
         transport_error = TransportError("mocked error")
         es_index_error_ctx = mock.patch(
             "time_execution.backends.elasticsearch.Elasticsearch.index",
@@ -132,7 +130,6 @@ class TestTimeExecution(BaseTestTimeExecutionElasticSearch):
 
     def test_with_origin(self):
         with settings(origin="unit_test"):
-
             go()
 
             for metric in self._query_backend(go.get_fqn())["hits"]["hits"]:

--- a/time_execution/backends/threaded.py
+++ b/time_execution/backends/threaded.py
@@ -56,7 +56,8 @@ class ThreadedBackend(BaseMetricsBackend):
         self.start_worker()
 
     def write(self, name, **data):
-        data["timestamp"] = datetime.datetime.utcnow()
+        if "timestamp" not in data:
+            data["timestamp"] = datetime.datetime.utcnow()
         try:
             self._queue.put_nowait((name, data))
         except Full:


### PR DESCRIPTION
The library doesn't know what format the index expects for the timestamp, and overwriting it with a python datetime object results in it getting serialized as an ISO timestamp regardless of what the application passes.