### PR TITLE
FIX: don't ignore the pipeline in ElasticSearch bulk_write

### DIFF
--- a/time_execution/backends/elasticsearch.py
+++ b/time_execution/backends/elasticsearch.py
@@ -69,7 +69,12 @@ class ElasticsearchBackend(BaseMetricsBackend):
         for metric in metrics:
             actions.append({"index": {"_index": index}})
             actions.append(metric)
+
+        bulk_params = {"operations": actions}
+        if self.pipeline:
+            bulk_params["pipeline"] = self.pipeline
+
         try:
-            self.client.bulk(operations=actions)
+            self.client.bulk(**bulk_params)
         except TransportError as exc:
             logger.warning("bulk_write metrics %r failure %r", metrics, exc)


### PR DESCRIPTION
The `pipeline` argument is only respected in the `write` function that does an `index` call to Elastic, but not in the `bulk_write` function that does a `bulk` call to Elastic.