### PR TITLE
NEW: generator hooks ✨

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ omit = ["tests/*"]
 [build-system]
 requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 
+[tool.mypy]
+warn_unused_configs = true
+
 [[tool.mypy.overrides]]
 module = ["mock", "freezegun", "elasticsearch.*", "fqn_decorators.*", "pkgsettings", "setuptools", "Queue"]
 ignore_missing_imports = true


### PR DESCRIPTION
### Motivation

I need to add some custom metric based on when exactly the decorated function got called: a background job start delay after its scheduled execution time.

### Implementation

In addition to simple functions, the decorator now accepts generator functions. That would allow them to run some code just before the decorated function gets called and remember the state.

Plain old hooks are not affected. The change is designed to be backwards-compatible.