### PR TITLE
FIX: `Hook` and `GeneratorHook` typing

### DIFF
--- a/time_execution/decorator.py
+++ b/time_execution/decorator.py
@@ -83,6 +83,7 @@ class Hook(Protocol):
 
     def __call__(
         self,
+        *,
         response: Any,
         exception: Optional[BaseException],
         metric: Dict[str, Any],
@@ -108,6 +109,7 @@ class GeneratorHook(Protocol):
 
     def __call__(
         self,
+        *,
         func: Callable[..., Any],
         func_args: Tuple[Any, ...],
         func_kwargs: Dict[str, Any],


### PR DESCRIPTION
By putting the star, I'm explicitly specifying that a hook is called with keyword arguments (was always the case)